### PR TITLE
RU-AXAV: Update README for go library

### DIFF
--- a/lib/go/README.md
+++ b/lib/go/README.md
@@ -24,14 +24,12 @@ under the License.
 Using Thrift with Go
 ====================
 
-Thrift supports Go 1.7+
+Thrift supports the currently officially supported Go releases (the latest 2).
 
-In following Go conventions, we recommend you use the 'go' tool to install
-Thrift for go.
+After initializing the go modules file in your project, use the following
+command to add the most recent version of the package:
 
-    $ go get github.com/apache/thrift/lib/go/thrift/...
-
-Will retrieve and install the most recent version of the package.
+    $ go get github.com/apache/thrift
 
 
 A note about optional fields


### PR DESCRIPTION
Because we briefly had go.mod file under lib/go/thrift in e27e82c46b
(it was later removed in d9fcdd3dba), using

    go get github.com/apache/thrift/lib/go/thrift/...

(as suggested by the current README) will get that particular version
instead of the latest released version. So update README to use

    go get github.com/apache/thrift

instead.

Also instead of saying we support Go 1.7+, say we support the officially
supported Go releases, as that's our new support policy.

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
